### PR TITLE
Add certs for x509 where go expects to find them.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Stephane Jourdan <fasten@fastmail.fm>
 ENV REFRESHED_AT 2015-10-14
 ENV VAULT_VERSION 0.3.1
 
+# x509 expects certs to be in this file only.
+ADD https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
 ADD https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip /tmp/vault.zip
 RUN cd /bin && unzip /tmp/vault.zip && chmod +x /bin/vault && rm /tmp/vault.zip
 


### PR DESCRIPTION
I've been using this docker for testing vault and at some point you use the AWS backend.

AWS requires HTTPS and for that go requires the certs to be in the file /etc/ssl/certs/ca-certificates.crt (https://golang.org/src/crypto/x509/root_linux.go)
Because you are using busybox the certs are all in /etc/ssl/certs but split in files and go will only check for split files for android as far as I know.

Error when using vault:
```
# vault read aws/creds/deploy
Error reading aws/creds/deploy: Error making API request.

URL: GET http://127.0.0.1:8200/v1/aws/creds/deploy
Code: 400. Errors:

* Error creating IAM user: RequestError: send request failed
caused by: Post https://iam.amazonaws.com/: x509: failed to load system roots and no roots provided
```

Hope it helps!