### PR TITLE
Improve vault client alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ The [WebGUI](http://a.b.c.d:8500/) should be available.
 
 You can use it as a `vault` client too:
 
-    $ alias vault="docker run vault"
+    $ alias vault="docker run --rm -e "VAULT_ADDR=$VAULT_ADDR" sjourdan/vault"
     $ vault version


### PR DESCRIPTION
--rm to remove all the dockers after command was executed.
-e to have your machine env set to it.

And the user of the docker was missing.