### PR TITLE
update to vault v0.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:latest
 MAINTAINER Stephane Jourdan <fasten@fastmail.fm>
-ENV REFRESHED_AT 2016-04-25
-ENV VAULT_VERSION 0.5.2
+ENV REFRESHED_AT 2016-06-13
+ENV VAULT_VERSION 0.5.3
 
 # x509 expects certs to be in this file only.
-RUN apk update && apk add openssl ca-certificates
+RUN apk update && apk add openssl ca-certificates && rm -rf /var/cache/apk/*
 
 # Download, unzip the given version of vault and set permissions
 RUN wget -qO /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The automated latest build is always available at [sjourdan/vault](https://regis
 Start vault server in a **dev mode**:
 
 ```
-docker run -it \
+docker run -d \
       -p 8200:8200 \
       --hostname vault \
       --name vault sjourdan/vault
@@ -30,7 +30,7 @@ docker run -it \
 Start with a **demo Consul backend** using [demo.consul.io](https://demo.consul.io):
 
 ```
-docker run -it \
+docker run -d \
       -p 8200:8200 \
       --hostname vault \
       --name vault \
@@ -52,7 +52,7 @@ docker run -p 8400:8400 -p 8500:8500 -p 8600:53/udp --hostname consul --name con
 When your consul service is started and accessible via links or DNS as consul, you can just start vault server using the following command:
 
 ```
-docker run -it \
+docker run -d \
       -p 8200:8200 \
       --hostname vault \
       --name vault \


### PR DESCRIPTION
- upgrade to vault v0.5.3
- reduce docker image size (-1MB)
- Run container in background